### PR TITLE
Remove Argyrios and Ben Langmuir as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,9 +8,4 @@
 # Order is important. The last matching pattern has the most precedence.
 
 # Owner of anything in IndexStoreDB not owned by anyone else.
-# N: Argyrios Kyrtzidis
-# E: kyrtzidis@apple.com
-# N: Ben Langmuir
-# E: blangmuir@apple.com
-
-*  @akyrtzi @benlangmuir @bnbarham
+*  @bnbarham


### PR DESCRIPTION
No longer have write access to the repo, which makes CODEOWNERS invalid.