### PR TITLE
[6.0] Import Bionic module from new Android overlay

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -19,6 +19,8 @@ import Foundation
 import Glibc
 #elseif os(Windows)
 import ucrt
+#elseif canImport(Android)
+import Android
 #else
 import Darwin.POSIX
 #endif

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -19,8 +19,8 @@ import Foundation
 import Glibc
 #elseif os(Windows)
 import ucrt
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #else
 import Darwin.POSIX
 #endif


### PR DESCRIPTION
__Explanation:__ Now that this new overlay was merged into the 6.0 compiler too in swiftlang/swift#74758, this adds the Bionic module from the overlay to the one file that currently adds `import Glibc`.

__Scope:__ Add import on Android only

__Issue:__ None

__Original PR:__ #211 and #213

__Risk:__ None

__Testing:__ Passed all CI on trunk, plus on my daily Android CI, finagolfin/swift-android-sdk#151

__Reviewer:__ @ahoppen

@bnbarham, easy review.