### PR TITLE
Ensure macOS logging uses UTF-8

### DIFF
--- a/lib/Support/Logging-Mac.mm
+++ b/lib/Support/Logging-Mac.mm
@@ -16,9 +16,11 @@
 #import <Foundation/Foundation.h>
 
 void IndexStoreDB::Log_impl(const char *loggerName, const char *message) {
-  // Using NSLog instead of stderr, to avoid interleaving with other log output in the process.
-  // NSLog also logs to asl.
-  NSLog(@"%s: %s", loggerName, message);
+  // Using NSLog instead of stderr, to avoid interleaving with other log output
+  // in the process. NSLog also logs to asl. Note that we need to print as an
+  // NSString here, since printing the C string with '%s' would use the default
+  // system encoding instead of UTF-8.
+  NSLog(@"%s: %@", loggerName, [NSString stringWithUTF8String:message]);
 }
 
 #endif


### PR DESCRIPTION
Previously we were using `NSLog`'s `%s` specifier, but that uses the default system encoding instead of UTF-8. Convert to NSString to ensure we can handle UTF-8 log messages.

rdar://131747774