### PR TITLE
[6.0] Ensure macOS logging uses UTF-8

### DIFF
--- a/lib/Support/Logging-Mac.mm
+++ b/lib/Support/Logging-Mac.mm
@@ -16,9 +16,11 @@
 #import <Foundation/Foundation.h>
 
 void IndexStoreDB::Log_impl(const char *loggerName, const char *message) {
-  // Using NSLog instead of stderr, to avoid interleaving with other log output in the process.
-  // NSLog also logs to asl.
-  NSLog(@"%s: %s", loggerName, message);
+  // Using NSLog instead of stderr, to avoid interleaving with other log output
+  // in the process. NSLog also logs to asl. Note that we need to print as an
+  // NSString here, since printing the C string with '%s' would use the default
+  // system encoding instead of UTF-8.
+  NSLog(@"%s: %@", loggerName, [NSString stringWithUTF8String:message]);
 }
 
 #endif


### PR DESCRIPTION
*6.0 cherry-pick of #214*

- Explanation: Fixes macOS logging to support UTF-8
- Scope: Affects logging on macOS
- Issue: rdar://131747774
- Risk: Low, only affects logging
- Testing: Verified locally
- Reviewer: Ben Barham