### PR TITLE
Add size for indexstoredb_symbol_role_t

### DIFF
--- a/Sources/IndexStoreDB/SymbolRole.swift
+++ b/Sources/IndexStoreDB/SymbolRole.swift
@@ -42,9 +42,7 @@ public struct SymbolRole: OptionSet, Hashable, Sendable {
 
   // MARK: Additional IndexStoreDB index roles
 
-  // Note: the imported constant INDEXSTOREDB_SYMBOL_ROLE_CANONICAL is signed by default and
-  // fails to construct in Swift.
-  public static let canonical: SymbolRole = SymbolRole(rawValue: 1 << 63)
+  public static let canonical: SymbolRole = SymbolRole(rawValue: INDEXSTOREDB_SYMBOL_ROLE_CANONICAL)
 
   public static let all: SymbolRole = SymbolRole(rawValue: ~0)
 

--- a/include/CIndexStoreDB/CIndexStoreDB.h
+++ b/include/CIndexStoreDB/CIndexStoreDB.h
@@ -59,7 +59,7 @@ typedef void *indexstoredb_symbol_location_t;
 typedef void *indexstoredb_symbol_relation_t;
 typedef void *indexstoredb_unit_info_t;
 
-typedef enum {
+typedef enum : uint64_t {
   INDEXSTOREDB_SYMBOL_ROLE_DECLARATION = 1 << 0,
   INDEXSTOREDB_SYMBOL_ROLE_DEFINITION  = 1 << 1,
   INDEXSTOREDB_SYMBOL_ROLE_REFERENCE   = 1 << 2,
@@ -82,7 +82,7 @@ typedef enum {
   INDEXSTOREDB_SYMBOL_ROLE_REL_IBTYPEOF    = 1 << 17,
   INDEXSTOREDB_SYMBOL_ROLE_REL_SPECIALIZATIONOF = 1 << 18,
 
-  INDEXSTOREDB_SYMBOL_ROLE_CANONICAL = 1 << 63,
+  INDEXSTOREDB_SYMBOL_ROLE_CANONICAL = (uint64_t)1 << 63,
 } indexstoredb_symbol_role_t;
 
 typedef enum {


### PR DESCRIPTION
This was previously miscompiling with clang (would be 32 bit instead of
64 bit) and now errors with clang 19. Note that this doesn't seem to
have had any impact within indexstore-db itself - the C++ side is
using a different enum (`SymbolRole`) which has:
```
Canonical = uint64_t(1) << 63,
```

And seems like the only real use of `Canonical` is
`foreachCanonicalSymbolOccurrenceImpl` itself (also C++).