### PR TITLE
Don’t try renaming `saved` index if it doesn’t exist

### DIFF
--- a/lib/Database/Database.cpp
+++ b/lib/Database/Database.cpp
@@ -155,7 +155,7 @@ Database::Implementation::create(StringRef path, bool readonly, Optional<size_t>
       return nullptr;
 
     // This succeeds for moving to an empty directory, like the newly constructed `uniqueDirPath`.
-    if (llvm::sys::fs::rename(savedPathBuf, uniqueDirPath)) {
+    if (!llvm::sys::fs::exists(savedPathBuf) || llvm::sys::fs::rename(savedPathBuf, uniqueDirPath)) {
       // No existing database, just use the new directory.
       existingDB = false;
     }


### PR DESCRIPTION
We were calling `llvm::sys::fs::rename` with the assumption that it fails immediately if `savedPathBuf` does not exist. But on Windows, the rename is retried 200 times with 10ms delay = for 2s, causing the creation of a new indexstore-db take 2s longer than necessary on Windows.

https://github.com/swiftlang/indexstore-db/blob/6120b53b1e8774ef4e2ad83438d4d94961331e72/lib/LLVMSupport/Support/Windows/Path.inc#L540-L543