### PR TITLE
A few miscellaneous updates

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -25,7 +25,7 @@ import Bionic
 import Darwin.POSIX
 #endif
 
-public struct PathMapping {
+public struct PathMapping: Equatable {
   /// Path prefix to be replaced, typically the canonical or hermetic path.
   let original: String
 

--- a/Sources/IndexStoreDB_CIndexStoreDB/CIndexStoreDB.cpp
+++ b/Sources/IndexStoreDB_CIndexStoreDB/CIndexStoreDB.cpp
@@ -176,6 +176,12 @@ indexstoredb_index_create(const char *storePath, const char *databasePath,
   return nullptr;
 }
 
+indexstoredb_index_t
+indexstoredb_index_create_from_existing(void *opaqueIndexSystem) {
+  std::shared_ptr<IndexSystem> *indexSystem = static_cast<std::shared_ptr<IndexSystem> *>(opaqueIndexSystem);
+  return make_object(*indexSystem);
+}
+
 void indexstoredb_index_add_delegate(indexstoredb_index_t index,
                                      indexstoredb_delegate_event_receiver_t delegateCallback) {
   auto delegate = std::make_shared<BlockIndexSystemDelegate>(delegateCallback);

--- a/Sources/IndexStoreDB_CIndexStoreDB/include/IndexStoreDB_CIndexStoreDB/CIndexStoreDB.h
+++ b/Sources/IndexStoreDB_CIndexStoreDB/include/IndexStoreDB_CIndexStoreDB/CIndexStoreDB.h
@@ -224,6 +224,12 @@ indexstoredb_index_create(const char * _Nonnull storePath,
                   indexstoredb_creation_options_t _Nonnull options,
                   indexstoredb_error_t _Nullable * _Nullable);
 
+/// Create an `indexstoredb_index_t` from an existing `std::shared_ptr<IndexSystem>`.
+///
+/// `opaqueIndexSystem` must be a `std::shared_ptr<IndexSystem> *`.
+INDEXSTOREDB_PUBLIC _Nonnull indexstoredb_index_t
+indexstoredb_index_create_from_existing(void *_Nonnull opaqueIndexSystem);
+
 /// Add an additional delegate to the given index.
 INDEXSTOREDB_PUBLIC void
 indexstoredb_index_add_delegate(_Nonnull indexstoredb_index_t index,

--- a/Sources/IndexStoreDB_Index/include/IndexStoreDB_Index/IndexStoreCXX.h
+++ b/Sources/IndexStoreDB_Index/include/IndexStoreDB_Index/IndexStoreCXX.h
@@ -55,6 +55,8 @@ public:
 
   bool hasPrefixMappings() const { return !prefixMap.empty(); }
 
+  const std::vector<std::pair<std::string, std::string>> &getPrefixMap() const { return prefixMap; }
+
   /// Convert this into a `indexstore_creation_options_t` that the caller
   /// owns and is responsible for disposing.
   indexstore_creation_options_t createOptions(const indexstore_functions_t &api) const {


### PR DESCRIPTION
- Make `PathMapping` equatable
- Allow creation of a Swift `IndexStoreDB` instance from an existing C++ `IndexSystem` type
- Support getting the prefix map from `IndexStoreCreationOptions`