### PR TITLE
Add function to explicitly import a unit

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -155,6 +155,13 @@ public final class IndexStoreDB {
     indexstoredb_index_poll_for_unit_changes_and_wait(impl, isInitialScan)
   }
 
+  /// Import the units for the given output paths into indexstore-db. Returns after the import has finished.
+  public func processUnitsForOutputPathsAndWait(_ outputPaths: some Collection<String>) {
+    let cOutputPaths: [UnsafePointer<CChar>] = outputPaths.map { UnsafePointer($0.withCString(strdup)!) }
+    defer { for cOutputPath in cOutputPaths { free(UnsafeMutablePointer(mutating: cOutputPath)) } }
+    indexstoredb_index_process_units_for_output_paths_and_wait(impl, cOutputPaths, cOutputPaths.count)
+  }
+
   /// Add output filepaths for the set of unit files that index data should be loaded from.
   /// Only has an effect if `useExplicitOutputUnits` was set to true at initialization.
   public func addUnitOutFilePaths(_ paths: [String], waitForProcessing: Bool) {

--- a/Sources/IndexStoreDB_CIndexStoreDB/CIndexStoreDB.cpp
+++ b/Sources/IndexStoreDB_CIndexStoreDB/CIndexStoreDB.cpp
@@ -220,6 +220,17 @@ void indexstoredb_index_poll_for_unit_changes_and_wait(indexstoredb_index_t inde
   obj->value->pollForUnitChangesAndWait(isInitialScan);
 }
 
+void indexstoredb_index_process_units_for_output_paths_and_wait(indexstoredb_index_t index,
+                                                                const char *const *outputPaths,
+                                                                size_t count) {
+  auto obj = (Object<std::shared_ptr<IndexSystem>> *)index;
+  SmallVector<StringRef, 32> strVec;
+  strVec.reserve(count);
+  for (unsigned i = 0; i != count; ++i)
+    strVec.push_back(outputPaths[i]);
+  obj->value->processUnitsForOutputPathsAndWait(strVec);
+}
+
 void indexstoredb_index_add_unit_out_file_paths(indexstoredb_index_t index,
                                                 const char *const *paths, size_t count,
                                                 bool waitForProcessing) {

--- a/Sources/IndexStoreDB_CIndexStoreDB/include/IndexStoreDB_CIndexStoreDB/CIndexStoreDB.h
+++ b/Sources/IndexStoreDB_CIndexStoreDB/include/IndexStoreDB_CIndexStoreDB/CIndexStoreDB.h
@@ -256,6 +256,12 @@ indexstoredb_store_version(_Nonnull indexstoredb_indexstore_library_t lib);
 INDEXSTOREDB_PUBLIC void
 indexstoredb_index_poll_for_unit_changes_and_wait(_Nonnull indexstoredb_index_t index, bool isInitialScan);
 
+/// Import the units for the given output paths into indexstore-db. Returns after the import has finished.
+INDEXSTOREDB_PUBLIC void
+indexstoredb_index_process_units_for_output_paths_and_wait(_Nonnull indexstoredb_index_t index,
+                                                           const char *_Nonnull const *_Nonnull outputPaths,
+                                                           size_t count);
+
 /// Add output filepaths for the set of unit files that index data should be loaded from.
 /// Only has an effect if `useExplicitOutputUnits` was set to true for `indexstoredb_index_create`.
 INDEXSTOREDB_PUBLIC void

--- a/Sources/IndexStoreDB_Index/IndexDatastore.h
+++ b/Sources/IndexStoreDB_Index/IndexDatastore.h
@@ -60,6 +60,9 @@ public:
   /// *For Testing* Poll for any changes to units and wait until they have been registered.
   void pollForUnitChangesAndWait(bool isInitialScan);
 
+  /// Import the units for the given output paths into indexstore-db. Returns after the import has finished.
+  void processUnitsForOutputPathsAndWait(ArrayRef<StringRef> outputPaths);
+
 private:
   IndexDatastore(void *Impl) : Impl(Impl) {}
 

--- a/Sources/IndexStoreDB_Index/IndexSystem.cpp
+++ b/Sources/IndexStoreDB_Index/IndexSystem.cpp
@@ -155,6 +155,9 @@ public:
   /// *For Testing* Poll for any changes to units and wait until they have been registered.
   void pollForUnitChangesAndWait(bool isInitialScan);
 
+  /// Import the units for the given output paths into indexstore-db. Returns after the import has finished.
+  void processUnitsForOutputPathsAndWait(ArrayRef<StringRef> outputPaths);
+
   void printStats(raw_ostream &OS);
 
   void dumpProviderFileAssociations(raw_ostream &OS);
@@ -339,6 +342,10 @@ void IndexSystemImpl::purgeStaleData() {
 void IndexSystemImpl::pollForUnitChangesAndWait(bool isInitialScan) {
   IndexStore->pollForUnitChangesAndWait(isInitialScan);
   DelegateWrap->_wait();
+}
+
+void IndexSystemImpl::processUnitsForOutputPathsAndWait(ArrayRef<StringRef> outputPaths) {
+  IndexStore->processUnitsForOutputPathsAndWait(outputPaths);
 }
 
 void IndexSystemImpl::printStats(raw_ostream &OS) {
@@ -721,6 +728,10 @@ void IndexSystem::purgeStaleData() {
 
 void IndexSystem::pollForUnitChangesAndWait(bool isInitialScan) {
   IMPL->pollForUnitChangesAndWait(isInitialScan);
+}
+
+void IndexSystem::processUnitsForOutputPathsAndWait(ArrayRef<StringRef> outputPaths) {
+  IMPL->processUnitsForOutputPathsAndWait(outputPaths);
 }
 
 void IndexSystem::printStats(raw_ostream &OS) {

--- a/Sources/IndexStoreDB_Index/include/IndexStoreDB_Index/IndexSystem.h
+++ b/Sources/IndexStoreDB_Index/include/IndexStoreDB_Index/IndexSystem.h
@@ -91,6 +91,9 @@ public:
   /// *For Testing* Poll for any changes to units and wait until they have been registered.
   void pollForUnitChangesAndWait(bool isInitialScan);
 
+  /// Import the units for the given output paths into indexstore-db. Returns after the import has finished.
+  void processUnitsForOutputPathsAndWait(ArrayRef<StringRef> outputPaths);
+
   void printStats(raw_ostream &OS);
 
   void dumpProviderFileAssociations(raw_ostream &OS);


### PR DESCRIPTION
We can call this from SourceKit-LSP when the indexing process has finished to ensure that we import the new unit into indexstore-db before declaring indexing done.