### PR TITLE
[FreeBSD] fix building on FreeBSD

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 
 import Foundation
 import PackageDescription
@@ -51,7 +51,9 @@ let package = Package(
 
     .testTarget(
       name: "IndexStoreDBTests",
-      dependencies: ["IndexStoreDB", "ISDBTestSupport"]),
+      dependencies: ["IndexStoreDB", "ISDBTestSupport"],
+      linkerSettings: [.linkedLibrary("execinfo", .when(platforms: [.custom("freebsd")]))]
+    ),
 
     // MARK: Swift Test Infrastructure
 

--- a/Sources/IndexStoreDB_LLVMSupport/include/IndexStoreDB_LLVMSupport/llvm_Config_config.h
+++ b/Sources/IndexStoreDB_LLVMSupport/include/IndexStoreDB_LLVMSupport/llvm_Config_config.h
@@ -144,7 +144,9 @@
 #endif
 
 /* Define to 1 if you have the `mallctl' function. */
-/* #undef HAVE_MALLCTL */
+#if defined(__FreeBSD__)
+#define HAVE_MALLCTL 1
+#endif
 
 /* Define to 1 if you have the `mallinfo' function. */
 /* #undef HAVE_MALLINFO */
@@ -180,7 +182,11 @@
 #define HAVE_PTHREAD_RWLOCK_INIT 1
 
 /* Define to 1 if you have the `sbrk' function. */
+#if defined(__FreeBSD__) && defined(__aarch64__)
+#undef HAVE_SBRK
+#else
 #define HAVE_SBRK 1
+#endif
 
 /* Define to 1 if you have the `setenv' function. */
 #define HAVE_SETENV 1

--- a/Utilities/import-llvm.d/include/llvm/Config/config.h
+++ b/Utilities/import-llvm.d/include/llvm/Config/config.h
@@ -180,7 +180,11 @@
 #define HAVE_PTHREAD_RWLOCK_INIT 1
 
 /* Define to 1 if you have the `sbrk' function. */
+#if defined(__FreeBSD__) && defined(__aarch64__)
+#undef HAVE_SBRK
+#else
 #define HAVE_SBRK 1
+#endif
 
 /* Define to 1 if you have the `setenv' function. */
 #define HAVE_SETENV 1


### PR DESCRIPTION
Fix building on FreeBSD
- adjust llvm config headers accordingly
  - `sark` is removed on aarch64 FreeBSD
- link against `execinfo` for test