### PR TITLE
[indexstore-db] Declare Codable conformance, to autosynthesize implementation.

### DIFF
--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -38,7 +38,7 @@ public struct PathMapping: Equatable {
   }
 }
 
-public enum SymbolProviderKind: Sendable {
+public enum SymbolProviderKind: Sendable, Codable {
   case clang
   case swift
 

--- a/Sources/IndexStoreDB/IndexStoreDBError.swift
+++ b/Sources/IndexStoreDB/IndexStoreDBError.swift
@@ -15,7 +15,7 @@ import IndexStoreDB_CIndexStoreDB
 
 import Foundation
 
-public enum IndexStoreDBError: Error {
+public enum IndexStoreDBError: Error, Codable {
   case create(String)
   case loadIndexStore(String)
 }

--- a/Sources/IndexStoreDB/Symbol.swift
+++ b/Sources/IndexStoreDB/Symbol.swift
@@ -13,7 +13,7 @@
 @_implementationOnly
 import IndexStoreDB_CIndexStoreDB
 
-public enum IndexSymbolKind: Hashable, Sendable {
+public enum IndexSymbolKind: Hashable, Sendable, Codable {
   case unknown
   case module
   case namespace
@@ -45,14 +45,14 @@ public enum IndexSymbolKind: Hashable, Sendable {
   case commentTag
 }
 
-public enum Language: Hashable, Sendable {
+public enum Language: Hashable, Sendable, Codable {
   case c
   case cxx
   case objc
   case swift
 }
 
-public struct Symbol: Hashable, Sendable {
+public struct Symbol: Hashable, Sendable, Codable {
 
   public var usr: String
   public var name: String

--- a/Sources/IndexStoreDB/SymbolLocation.swift
+++ b/Sources/IndexStoreDB/SymbolLocation.swift
@@ -14,7 +14,7 @@
 import IndexStoreDB_CIndexStoreDB
 import Foundation
 
-public struct SymbolLocation: Equatable, Sendable {
+public struct SymbolLocation: Equatable, Sendable, Codable {
   public var path: String
   /// The date at which the unit file that contains a symbol has last been modified.
   public var timestamp: Date

--- a/Sources/IndexStoreDB/SymbolOccurrence.swift
+++ b/Sources/IndexStoreDB/SymbolOccurrence.swift
@@ -13,7 +13,7 @@
 @_implementationOnly
 import IndexStoreDB_CIndexStoreDB
 
-public struct SymbolOccurrence: Equatable {
+public struct SymbolOccurrence: Equatable, Codable {
   public var symbol: Symbol
   public var location: SymbolLocation
   public var roles: SymbolRole
@@ -48,7 +48,7 @@ extension SymbolOccurrence: CustomStringConvertible {
   }
 }
 
-public struct SymbolRelation: Equatable {
+public struct SymbolRelation: Equatable, Codable {
   public var symbol: Symbol
   public var roles: SymbolRole
 

--- a/Sources/IndexStoreDB/SymbolProperty.swift
+++ b/Sources/IndexStoreDB/SymbolProperty.swift
@@ -13,7 +13,7 @@
 @_implementationOnly
 import IndexStoreDB_CIndexStoreDB
 
-public struct SymbolProperty: OptionSet, Hashable, Sendable {
+public struct SymbolProperty: OptionSet, Hashable, Sendable, Codable {
   public var rawValue: UInt64
 
   public static let generic: SymbolProperty = SymbolProperty(rawValue: INDEXSTOREDB_SYMBOL_PROPERTY_GENERIC)

--- a/Sources/IndexStoreDB/SymbolRole.swift
+++ b/Sources/IndexStoreDB/SymbolRole.swift
@@ -13,7 +13,7 @@
 @_implementationOnly
 import IndexStoreDB_CIndexStoreDB
 
-public struct SymbolRole: OptionSet, Hashable, Sendable {
+public struct SymbolRole: OptionSet, Hashable, Sendable, Codable {
 
   public var rawValue: UInt64
 


### PR DESCRIPTION
This PR adds `Codable` support to the `SymbolOccurrence` and `Symbol` models, in addition to types they depend on. (`SymbolRole`, etc) 

**Why?** 
- I found a need for this while trying to work with actors to parallelize index access.
- Clients code depending on `indexstore-db` would need to manually implement conformance, because conformances in extensions are not synthesized.

**Risks** 
- Additions to these models would need to support `Codable` as well. (Compiler will catch this.)
- Changes may cause unexpected results when deserializing. (Mitigated with unit tests)