### PR TITLE
Adopt Sendability in Remaining Models

### DIFF
--- a/Sources/IndexStoreDB/IndexDelegate.swift
+++ b/Sources/IndexStoreDB/IndexDelegate.swift
@@ -12,13 +12,13 @@
 
 @_implementationOnly import IndexStoreDB_CIndexStoreDB
 
-public struct StoreUnitInfo {
+public struct StoreUnitInfo: Sendable {
   public let mainFilePath: String
   public let unitName: String
 }
 
 /// Delegate for index events.
-public protocol IndexDelegate: AnyObject {
+public protocol IndexDelegate: AnyObject, Sendable {
 
   /// The index will process `count` unit files.
   func processingAddedPending(_ count: Int)

--- a/Sources/IndexStoreDB/IndexDelegate.swift
+++ b/Sources/IndexStoreDB/IndexDelegate.swift
@@ -18,7 +18,7 @@ public struct StoreUnitInfo: Sendable {
 }
 
 /// Delegate for index events.
-public protocol IndexDelegate: AnyObject, Sendable {
+public protocol IndexDelegate: AnyObject {
 
   /// The index will process `count` unit files.
   func processingAddedPending(_ count: Int)

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -55,7 +55,7 @@ public enum SymbolProviderKind: Sendable {
 }
 
 /// IndexStoreDB index.
-public final class IndexStoreDB: @unchecked Sendable {
+public final class IndexStoreDB {
 
   let delegate: IndexDelegate?
   let impl: UnsafeMutableRawPointer // indexstoredb_index_t

--- a/Sources/IndexStoreDB/IndexStoreDB.swift
+++ b/Sources/IndexStoreDB/IndexStoreDB.swift
@@ -25,7 +25,7 @@ import Bionic
 import Darwin.POSIX
 #endif
 
-public struct PathMapping: Equatable {
+public struct PathMapping: Equatable, Sendable {
   /// Path prefix to be replaced, typically the canonical or hermetic path.
   public let original: String
 
@@ -55,7 +55,7 @@ public enum SymbolProviderKind: Sendable {
 }
 
 /// IndexStoreDB index.
-public final class IndexStoreDB {
+public final class IndexStoreDB: @unchecked Sendable {
 
   let delegate: IndexDelegate?
   let impl: UnsafeMutableRawPointer // indexstoredb_index_t

--- a/Sources/IndexStoreDB/IndexStoreDBError.swift
+++ b/Sources/IndexStoreDB/IndexStoreDBError.swift
@@ -15,7 +15,7 @@ import IndexStoreDB_CIndexStoreDB
 
 import Foundation
 
-public enum IndexStoreDBError: Error {
+public enum IndexStoreDBError: Error, Sendable {
   case create(String)
   case loadIndexStore(String)
 }

--- a/Sources/IndexStoreDB/SymbolOccurrence.swift
+++ b/Sources/IndexStoreDB/SymbolOccurrence.swift
@@ -13,7 +13,7 @@
 @_implementationOnly
 import IndexStoreDB_CIndexStoreDB
 
-public struct SymbolOccurrence: Equatable {
+public struct SymbolOccurrence: Equatable, Sendable {
   public var symbol: Symbol
   public var location: SymbolLocation
   public var roles: SymbolRole
@@ -48,7 +48,7 @@ extension SymbolOccurrence: CustomStringConvertible {
   }
 }
 
-public struct SymbolRelation: Equatable {
+public struct SymbolRelation: Equatable, Sendable {
   public var symbol: Symbol
   public var roles: SymbolRole
 


### PR DESCRIPTION
Several structs already declared Sendable conformance. This PR adds support to (most of) the remaining ones.

- `SymbolOccurrence` and `SymbolRelation` are easy and safe changes.
- `IndexStoreDBError`, `PathMapping`, and `StoreUnitInfo` are similar, but I don't know if this change is what you had in mind, @ahoppen.

Less safe changes:
- `IndexDelegate` can be useful to wrap in a Swift actor, so I'd _like_ to mark this as Sendable, but am unsure if this is wise, given there's mention of asynchronous behavior within that protocol.
- `IndexStoreDB` contains an `UnsafeMutableRawPointer` so the best that we can do (with what I'm aware of) is `@unchecked Sendable`.

Reviewers: Please let me know if any of these changes should be adjusted and/or how we might test this beyond visual inspection.

Addresses conversation on #248 and issues #250. 