### PR TITLE
 Update dependant packages to match 6.2.1 branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ var dependencies: [Package.Dependency] {
     ]
   } else {
     return [
-      .package(url: "https://github.com/swiftlang/swift-lmdb.git", branch: "release/6.2"),
+      .package(url: "https://github.com/swiftlang/swift-lmdb.git", branch: "release/6.2.1"),
     ]
   }
 }


### PR DESCRIPTION
Update the dependant packages to match 6.2.1, so parent
    dependencies like sourcekit-lsp will not have version errors